### PR TITLE
feat: add ability to use source as content

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,41 @@ That's all! The timeline block will automatically be processed, and each section
 
 ### A Bit More
 
+#### Block Content
+
+You can either format it this way, where the timeline block renders content using the text outside the block:  
+
+````md
+Today. Slow breakfast. Organized, felt good. Watched a space doc, had veggies and quinoa.
+
+Tomorrow. Quick jog. Worked on a project. Dinner with friends.
+
+Dec 31. Walked, reflected. Last-minute shopping. Celebrated with friends.
+
+Jan 1. Slept in, journaled. Walked, read. Quiet night, healthy meal, episodes.
+
+Jan 2. Made a plan. Caught up on emails, watched snow. Tried chili, read.
+
+```timeline
+```
+````
+
+Or, you can format it this way, by placing the content inside the block. However, this approach does not allow you to use [explicit settings](#customizing-the-source-block):  
+
+````md
+```timeline
+Today. Slow breakfast. Organized, felt good. Watched a space doc, had veggies and quinoa.
+
+Tomorrow. Quick jog. Worked on a project. Dinner with friends.
+
+Dec 31. Walked, reflected. Last-minute shopping. Celebrated with friends.
+
+Jan 1. Slept in, journaled. Walked, read. Quiet night, healthy meal, episodes.
+
+Jan 2. Made a plan. Caught up on emails, watched snow. Tried chili, read.
+```
+````
+
 #### Dates
 
 Each section's date is determined by the first valid date mentioned in the section. You can use various formats supported by [Chronos](https://github.com/wanasit/chrono), including:

--- a/main.ts
+++ b/main.ts
@@ -96,22 +96,22 @@ export default class EasyTimelinePlugin extends Plugin {
 			// Read file content
 			const text = await this.app.vault.read(file);
 
-			// Remove frontmatter and source block from file content
-			let { contentStart } = getFrontMatterInfo(text);
-			const sourceBlock = "```" + language + "\n" + source + "\n```";
-			const content = text.slice(contentStart).replace(sourceBlock, '');
-
 			// Get and process all metadata from source block
 			const metadata = extractVariedMetadata(source);
 			const metadataReference = metadata.reference ? strict.parseDate(metadata.reference) : null;
 			const metadataSort = metadata.sort ? { ascending: 'asc', descending: 'desc' }[metadata.sort.toLowerCase()] || metadata.sort : null;
 			const sort = ((metadataSort === 'asc' || metadataSort === 'desc') ? metadataSort : this.settings.sort);
 
+			// Remove frontmatter and source block from file content
+			let { contentStart } = getFrontMatterInfo(text);
+			const sourceBlock = "```" + language + "\n" + source + "\n```";
+			const content = source.length != 0 && Object.keys(metadata).length === 0 ? source : text;
+
 			// find reference date in content
 			const reference = metadataReference ?? (await this.findReference(file));
 
 			// Get timeline object representation
-			const timeline = content
+			const timeline = content.slice(contentStart).replace(sourceBlock, '')
 				.split(this.settings.singleLine ? '\n' : '\n\n') // Split content into lines and process dates for each lines
 				.map(line => {
 					return {
@@ -122,7 +122,7 @@ export default class EasyTimelinePlugin extends Plugin {
 				.filter(value => value.date != null) as TimelineData // Don't include lines with no valid dates
 
 			// Render timeline
-			const timelineEl = renderTimeline(timeline, sort as "asc" | "desc", );
+			const timelineEl = renderTimeline(timeline, sort as "asc" | "desc",);
 			el.replaceWith(timelineEl)
 		});
 	}


### PR DESCRIPTION
You can now use the timeline source block as the content if there is no explicit settings.

````md
```timeline
Today. Slow breakfast. Organized, felt good. Watched a space doc, had veggies and quinoa.

Tomorrow. Quick jog. Worked on a project. Dinner with friends.

Dec 31. Walked, reflected. Last-minute shopping. Celebrated with friends.

Jan 1. Slept in, journaled. Walked, read. Quiet night, healthy meal, episodes.

Jan 2. Made a plan. Caught up on emails, watched snow. Tried chili, read.
```
````

resolve #1